### PR TITLE
Benchmarks fix

### DIFF
--- a/Benchmarks/Program.cs
+++ b/Benchmarks/Program.cs
@@ -11,9 +11,9 @@ namespace Benchmarks
         public static void Main(string[] args)
         {
             var config = DefaultConfig.Instance
-                //.With(Job.Default.With(CsProjClassicNetToolchain.Net472))
-                .With(Job.Default.With(CsProjCoreToolchain.NetCoreApp31))
-                .With(Job.Default.With(CsProjCoreToolchain.From(new NetCoreAppSettings("net5.0-windows", null, ".NET 5.0"))))
+                //.AddJob(Job.Default.With(CsProjClassicNetToolchain.Net472))
+                .AddJob(Job.Default.WithToolchain(CsProjCoreToolchain.NetCoreApp31))
+                .AddJob(Job.Default.WithToolchain(CsProjCoreToolchain.From(new NetCoreAppSettings("net5.0-windows", null, ".NET 5.0"))))
                 ;
 
             BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, config);

--- a/Benchmarks/Program.cs
+++ b/Benchmarks/Program.cs
@@ -13,7 +13,7 @@ namespace Benchmarks
             var config = DefaultConfig.Instance
                 //.With(Job.Default.With(CsProjClassicNetToolchain.Net472))
                 .With(Job.Default.With(CsProjCoreToolchain.NetCoreApp31))
-                .With(Job.Default.With(CsProjCoreToolchain.From(new NetCoreAppSettings("netcoreapp5.0", null, ".NET Core 5.0"))))
+                .With(Job.Default.With(CsProjCoreToolchain.From(new NetCoreAppSettings("net5.0-windows", null, ".NET 5.0"))))
                 ;
 
             BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, config);

--- a/Benchmarks/Program.cs
+++ b/Benchmarks/Program.cs
@@ -11,7 +11,7 @@ namespace Benchmarks
         public static void Main(string[] args)
         {
             var config = DefaultConfig.Instance
-                //.AddJob(Job.Default.With(CsProjClassicNetToolchain.Net472))
+                .AddJob(Job.Default.WithToolchain(CsProjClassicNetToolchain.Net472))
                 .AddJob(Job.Default.WithToolchain(CsProjCoreToolchain.NetCoreApp31))
                 .AddJob(Job.Default.WithToolchain(CsProjCoreToolchain.From(new NetCoreAppSettings("net5.0-windows", null, ".NET 5.0"))))
                 ;

--- a/Benchmarks/Program.cs
+++ b/Benchmarks/Program.cs
@@ -1,22 +1,14 @@
-﻿using BenchmarkDotNet.Configs;
-using BenchmarkDotNet.Jobs;
-using BenchmarkDotNet.Running;
-using BenchmarkDotNet.Toolchains.CsProj;
-using BenchmarkDotNet.Toolchains.DotNetCli;
+﻿using BenchmarkDotNet.Running;
 
 namespace Benchmarks
 {
     public class Program
     {
-        public static void Main(string[] args)
-        {
-            var config = DefaultConfig.Instance
-                .AddJob(Job.Default.WithToolchain(CsProjClassicNetToolchain.Net472))
-                .AddJob(Job.Default.WithToolchain(CsProjCoreToolchain.NetCoreApp31))
-                .AddJob(Job.Default.WithToolchain(CsProjCoreToolchain.From(new NetCoreAppSettings("net5.0-windows", null, ".NET 5.0"))))
-                ;
-
-            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, config);
-        }
+        /// <summary>
+        /// usage:
+        /// dotnet run -c Release -f $moniker --filter * --runtimes net472 netcoreapp31 net5.0-windows
+        /// </summary>
+        /// <param name="args"></param>
+        public static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
     }
 }

--- a/Benchmarks/WinFormsBenchmarks.csproj
+++ b/Benchmarks/WinFormsBenchmarks.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1.1513" />
   </ItemGroup>
 
   <Import Sdk="Microsoft.NET.Sdk.WindowsDesktop" Project="Sdk.targets" Condition="'$(TargetFramework)' != 'net472'"/>

--- a/Benchmarks/WinFormsBenchmarks.csproj
+++ b/Benchmarks/WinFormsBenchmarks.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Sdk="Microsoft.NET.Sdk.WindowsDesktop" Project="Sdk.props" Condition="'$(TargetFramework)' != 'net472'"/>
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1;net5.0-windows</TargetFrameworks>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <UseWindowsForms>true</UseWindowsForms>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    <add key="bdn-ci" value="https://ci.appveyor.com/nuget/benchmarkdotnet" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
@RussKie the most important change was to bump BDN version to the one that supports OS-specific TFMs.

I've removed the code config definition as it's [recommended](https://benchmarkdotnet.org/articles/configs/toolchains.html#multiple-frameworks-support) to pass it via console line args:

```cmd
dotnet run -c Release -f netcoreapp3.1 --filter * --runtimes net472 netcoreapp31 net5.0-windows
```

Sample results:

```ini
BenchmarkDotNet=v0.12.1.1513-nightly, OS=Windows 10.0.18363.1316 (1909/November2019Update/19H2)
Intel Xeon CPU E5-1650 v4 3.60GHz, 1 CPU, 12 logical and 6 physical cores
.NET SDK=5.0.102
  [Host]     : .NET Core 3.1.11 (CoreCLR 4.700.20.56602, CoreFX 4.700.20.56604), X64 RyuJIT
  Job-JGZOBN : .NET 5.0.2 (5.0.220.61120), X64 RyuJIT
  Job-SCAMBS : .NET Core 3.1.11 (CoreCLR 4.700.20.56602, CoreFX 4.700.20.56604), X64 RyuJIT
  Job-ZTSIMQ : .NET Framework 4.8 (4.8.4250.0), X64 RyuJIT


|            Method |        Job |            Toolchain |      Mean |     Error |    StdDev |    Median | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------ |----------- |--------------------- |----------:|----------:|----------:|----------:|------:|------:|------:|----------:|
| CreateAndShowForm | Job-JGZOBN |             .NET 5.0 |  8.851 ms | 0.1749 ms | 0.3572 ms |  8.789 ms |     - |     - |     - |      3 KB |
| CreateAndShowForm | Job-SCAMBS |        .NET Core 3.1 | 18.972 ms | 0.3599 ms | 0.3366 ms | 18.926 ms |     - |     - |     - |      3 KB |
| CreateAndShowForm | Job-ZTSIMQ | .NET Framework 4.7.2 | 14.095 ms | 1.4101 ms | 4.1576 ms | 11.959 ms |     - |     - |     - |      6 KB |
